### PR TITLE
Generate Dockerfile from upstream

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
     {
       "description": "Update actions/runner version",
       "fileMatch": ["^\\.github/workflows/build\\.yaml$"],
-      "matchStrings": ["RUNNER_VERSION=(?<currentValue>.*?)\\s"],
+      "matchStrings": ["RUNNER_VERSION: (?<currentValue>.*?)\\s"],
       "depNameTemplate": "actions/runner",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
       - run: make -C hack
       - run: cp hack/Dockerfile.generated Dockerfile
-      - uses: int128/update-generated-files-action@v2
+      - uses: int128/update-generated-files-action@v2.38.0
 
   image:
     needs: generate-dockerfile-from-upstream

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,18 +6,33 @@ on:
       - .github/workflows/build.yaml
       - Dockerfile
       - entrypoint.sh
+      - hack/**
   push:
     paths:
       - .github/workflows/build.yaml
       - Dockerfile
       - entrypoint.sh
+      - hack/**
     branches:
       - main
     tags:
       - '*'
 
+env:
+  RUNNER_VERSION: 2.304.0
+
 jobs:
+  generate-dockerfile-from-upstream:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - run: make -C hack
+      - run: cp hack/Dockerfile.generated Dockerfile
+      - uses: int128/update-generated-files-action@v2
+
   image:
+    needs: generate-dockerfile-from-upstream
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -50,7 +65,7 @@ jobs:
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
           build-args: |
-            RUNNER_VERSION=2.304.0
+            RUNNER_VERSION=${{ env.RUNNER_VERSION }}
           platforms: |
             linux/amd64
             linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
-### DO NOT EDIT THIS BLOCK ###
-### COPY FROM https://github.com/actions/runner/pull/2630 ###
+### DO NOT EDIT BELOW
+### BEGIN OF GENERATED BLOCK
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0 as build
 
-ARG TARGETARCH
 ARG RUNNER_VERSION
-ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.2
+ARG RUNNER_ARCH="x64"
+ARG RUNNER_CONTAINER_HOOKS_VERSION=0.3.1
 ARG DOCKER_VERSION=20.10.23
 
 RUN apt update -y && apt install curl unzip -y
 
 WORKDIR /actions-runner
-RUN export RUNNER_ARCH="x64" \
-    && if [ "$TARGETARCH" = "arm64" ]; then export RUNNER_ARCH=arm64 ; fi \
-    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
+
+# Do not use RUNNER_ARCH, because we leave it to avoid conflict on patch
+ARG TARGETARCH
+RUN export RUNNER_ARCH_THIS="x64" \
+    && if [ "$TARGETARCH" = "arm64" ]; then export RUNNER_ARCH_THIS=arm64 ; fi \
+    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH_THIS}-${RUNNER_VERSION}.tar.gz \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz
 
@@ -51,8 +54,8 @@ COPY --chown=runner:docker --from=build /actions-runner .
 RUN install -o root -g root -m 755 docker/* /usr/bin/ && rm -rf docker
 
 USER runner
-### END OF actions/runner#2630 ###
-### DO NOT EDIT ABOVE ###
+### END OF GENERATED BLOCK
+### DO NOT EDIT ABOVE
 
 ### Once actions/runner#2630 is accepted, we will be able to set the base image:
 # FROM ghcr.io/actions/actions-runner:2.304.0

--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ As well as we add some packages for our workflows.
 We'd like to keep the image small as possible.
 DO NOT add any package unless we really need it.
 
-## Principles
-
 For long-term maintainability and security,
 
 - Align to the official image
 - Less image size as possible
 - Less logic as possible
+
+## Release
+
+Renovate creates a pull request to update the runner version.
+The workflow updates Dockerfile from [upstream](https://github.com/actions/runner/blob/main/images/Dockerfile).
+
+Then, we manually [create a release](https://github.com/quipper/actions-runner/releases).

--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -1,0 +1,1 @@
+/Dockerfile.*

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -1,0 +1,22 @@
+# This Makefile generates a Dockerfile from upstream with multi-architectures patch.
+# It is needed until GitHub officially provides a multi-architectures image.
+# https://github.com/orgs/community/discussions/56720
+
+all: Dockerfile.generated
+
+Dockerfile.official:
+ifndef RUNNER_VERSION
+	$(error usage: make RUNNER_VERSION=x.y.z)
+endif
+	curl -sf -o $@ https://raw.githubusercontent.com/actions/runner/v$(RUNNER_VERSION)/images/Dockerfile
+
+Dockerfile.multiarch: Dockerfile.official multiarch.patch
+	patch -o $@ Dockerfile.official multiarch.patch
+
+Dockerfile.generated: Dockerfile.multiarch ../Dockerfile
+	echo '### DO NOT EDIT BELOW' > $@
+	echo '### BEGIN OF GENERATED BLOCK' >> $@
+	cat Dockerfile.multiarch >> $@
+	echo '### END OF GENERATED BLOCK' >> $@
+	# https://stackoverflow.com/questions/197150/skip-file-lines-until-a-match-is-found-then-output-the-rest
+	sed -e '1,/^### END OF GENERATED BLOCK/d' ../Dockerfile >> $@

--- a/hack/multiarch.patch
+++ b/hack/multiarch.patch
@@ -1,0 +1,25 @@
+--- Dockerfile.official	2023-06-01 09:14:26
++++ Dockerfile.multiarch	2023-06-01 09:32:57
+@@ -8,7 +8,12 @@
+ RUN apt update -y && apt install curl unzip -y
+ 
+ WORKDIR /actions-runner
+-RUN curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
++
++# Do not use RUNNER_ARCH, because we leave it to avoid conflict on patch
++ARG TARGETARCH
++RUN export RUNNER_ARCH_THIS="x64" \
++    && if [ "$TARGETARCH" = "arm64" ]; then export RUNNER_ARCH_THIS=arm64 ; fi \
++    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH_THIS}-${RUNNER_VERSION}.tar.gz \
+     && tar xzf ./runner.tar.gz \
+     && rm runner.tar.gz
+ 
+@@ -17,7 +22,7 @@
+     && rm runner-container-hooks.zip
+ 
+ RUN export DOCKER_ARCH=x86_64 \
+-    && if [ "$RUNNER_ARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
++    && if [ "$TARGETARCH" = "arm64" ]; then export DOCKER_ARCH=aarch64 ; fi \
+     && curl -fLo docker.tgz https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
+     && tar zxvf docker.tgz \
+     && rm -rf docker.tgz


### PR DESCRIPTION
## Problem to solve
When the upstream Dockerfile is changed, we need to manually update this repository.

## How to solve
Fetch a tagged upstream (e.g. https://github.com/actions/runner/blob/v2.304.0/images/Dockerfile) and patch it in GitHub Actions.
