### PR TITLE
Add packages of actions-runner-controller/runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,22 @@ USER runner
 
 RUN sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends \
-        build-essential \
+        # packages in actions-runner-controller/runner-22.04
+        curl \
         git \
+        jq \
+        unzip \
+        zip \
+        # packages in actions-runner-controller/runner-20.04
+        build-essential \
+        locales \
+        tzdata \
+        # dockerd dependencies
         tini \
         iptables
 
 # KEEP LESS PACKAGES:
-# It is the best practice to keep this image small for maintanability and security.
+# We'd like to keep this image small for maintanability and security.
 # See also,
 # https://github.com/actions/actions-runner-controller/pull/2050
 # https://github.com/actions/actions-runner-controller/blob/master/runner/actions-runner.ubuntu-22.04.dockerfile


### PR DESCRIPTION
I'd like to add some packages which are included in actions-runner-controller/runner image.

This change will increase about 200MB of the image size.

```
% docker images
REPOSITORY                       TAG                     IMAGE ID       CREATED          SIZE
quipper-actions-runner           latest                  67f315eec610   3 seconds ago    1.06GB
ghcr.io/quipper/actions-runner   2.304.0                 b149e930c9e3   4 hours ago      1.04GB
```