### PR TITLE
Mount `/var/lib/docker` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ RUN mkdir /opt/hostedtoolcache \
 
 COPY entrypoint.sh /
 
+VOLUME /var/lib/docker
+
 # some setup actions depend on ImageOS variable
 # https://github.com/actions/runner-images/issues/345
 ENV ImageOS=ubuntu22


### PR DESCRIPTION
Dockerd stores container volumes into `/var/lib/docker`.
For Kubernetes, it should be mounted as an empty dir for performance.

## References
https://github.com/actions/actions-runner-controller/blob/ae8b27a9a32ac732b80f0496a2c97dadb0119cd2/runner/actions-runner-dind.ubuntu-22.04.dockerfile#L104
https://github.com/docker-library/docker/blob/36a4df919e51b459eaf08c2f7d395b71d8e331c3/24/dind/Dockerfile#L85
