### PR TITLE
Pin helm version to v3.12.3

### DIFF
--- a/e2e-test/aqua.yaml
+++ b/e2e-test/aqua.yaml
@@ -3,3 +3,4 @@ registries:
     ref: v4.57.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: helmfile/helmfile@v0.157.0
+  - name: helm/helm@v3.12.3


### PR DESCRIPTION
Currently, e2e-test is failing due to the error:

> https://github.com/quipper/actions-runner/actions/runs/6477803523/job/17588590669?pr=137
>   Error: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://ghcr.io/token?scope=repository%3Aactions%2Factions-runner-controller-charts%2Fgha-runner-scale-set-controller%3Apull&scope=repository%3Auser%2Fimage%3Apull&service=ghcr.io: 403 Forbidden


It seems Helm 3.13.0 has a bug as https://github.com/helm/helm/issues/12423.
