### PR TITLE
Run e2e-test sequentially

### DIFF
--- a/.github/workflows/reusable--build-and-test.yaml
+++ b/.github/workflows/reusable--build-and-test.yaml
@@ -76,6 +76,11 @@ jobs:
 
   e2e-test:
     needs: build
+    concurrency:
+      # When multiple actions-runner-controller are running at the same time,
+      # a runner registration is eventually deleted.
+      # For now, run the e2e-test sequentially.
+      group: e2e-test
     uses: ./.github/workflows/reusable--e2e-test.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
Recently, e2e-test is failing due to the below errors.
https://github.com/quipper/actions-runner/actions/runs/7001331464/job/19043287728

### Runner

> Mon, 27 Nov 2023 06:17:29 GMT
> Failed to create a session. The runner registration has been deleted from the server, please re-configure. Runner registrations are automatically deleted for runners that have not connected to the service recently.
> Mon, 27 Nov 2023 06:17:29 GMT
> Runner listener exit with terminated error, stop the service, no retry needed.
> Mon, 27 Nov 2023 06:17:29 GMT
> Exiting runner...

### Controller

> 2023-11-27T06:17:29Z	INFO	EphemeralRunner	Checking if runner exists in GitHub service	{"ephemeralrunner": {"name":"runner-7001331464-6hjkp-runner-jhsxm","namespace":"arc-runners"}, "runnerId": 1609}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunner	Runner does not exist in GitHub service	{"ephemeralrunner": {"name":"runner-7001331464-6hjkp-runner-jhsxm","namespace":"arc-runners"}, "runnerId": 1609}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunner	Ephemeral runner has finished since it does not exist in the service anymore	{"ephemeralrunner": {"name":"runner-7001331464-6hjkp-runner-jhsxm","namespace":"arc-runners"}}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunner	Updating ephemeral runner status to Finished	{"ephemeralrunner": {"name":"runner-7001331464-6hjkp-runner-jhsxm","namespace":"arc-runners"}}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunner	EphemeralRunner status is marked as Finished	{"ephemeralrunner": {"name":"runner-7001331464-6hjkp-runner-jhsxm","namespace":"arc-runners"}}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunnerSet	Ephemeral runner counts	{"ephemeralrunnerset": {"name":"runner-7001331464-6hjkp","namespace":"arc-runners"}, "pending": 0, "running": 0, "finished": 1, "failed": 0, "deleting": 0}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunnerSet	Deleting finished ephemeral runner	{"ephemeralrunnerset": {"name":"runner-7001331464-6hjkp","namespace":"arc-runners"}, "name": "runner-7001331464-6hjkp-runner-jhsxm"}
> 2023-11-27T06:17:29Z	INFO	EphemeralRunner	EphemeralRunner has already finished. Stopping reconciliation and waiting for EphemeralRunnerSet to clean it up	{"ephemeralrunner": {"name":"runner-7001331464-6hjkp-runner-jhsxm","namespace":"arc-runners"}, "phase": "Succeeded"}
> 
