### PR TITLE
ghをimageに含めるように修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN sudo apt-get update -y \
         libyaml-dev \
         # dockerd dependencies
         tini \
-        iptables
+        iptables \
+        gh
 
 # KEEP LESS PACKAGES:
 # We'd like to keep this image small for maintanability and security.

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -25,7 +25,8 @@ RUN apt-get update -y \
         libyaml-dev \
         # dockerd dependencies
         tini \
-        iptables
+        iptables \
+        gh
 
 # KEEP LESS PACKAGES:
 # We'd like to keep this image small for maintanability and security.


### PR DESCRIPTION
monorepoのworkflowでghコマンドを使いたいことがあり、都度workflowでインストールするのも非効率なので追加しました。

いじる場所が違っていたら教えてください！