### PR TITLE
Update actions-runner-controller-charts/gha-runner-scale-set to 0.9.0

### DIFF
--- a/e2e-test/helmfile.yaml
+++ b/e2e-test/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
     name: {{ requiredEnv "ARC_RUNNER_NAME" | quote }}
     namespace: arc-runners
     chart: actions-runner-controller-charts/gha-runner-scale-set
-    version: 0.8.3
+    version: 0.9.0
     values:
       - githubConfigUrl: https://github.com/{{ requiredEnv "GITHUB_REPOSITORY" }}
         githubConfigSecret:
@@ -34,7 +34,7 @@ releases:
     name: {{ requiredEnv "ARC_RUNNER_UBUNTU20_NAME" | quote }}
     namespace: arc-runners
     chart: actions-runner-controller-charts/gha-runner-scale-set
-    version: 0.8.3
+    version: 0.9.0
     values:
       - githubConfigUrl: https://github.com/{{ requiredEnv "GITHUB_REPOSITORY" }}
         githubConfigSecret:


### PR DESCRIPTION
Follow up:
- https://github.com/quipper/actions-runner/pull/353