### PR TITLE
Replace tini with docker-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN sudo apt-get update -y \
         # https://github.com/ruby/setup-ruby#using-self-hosted-runners
         libyaml-dev \
         # dockerd dependencies
-        tini \
         iptables
 
 # KEEP LESS PACKAGES:
@@ -46,11 +45,11 @@ VOLUME /var/lib/docker
 # https://github.com/actions/runner-images/issues/345
 ENV ImageOS=ubuntu22
 
-# tini sends the signal to children
+# docker-init sends the signal to children
 ENV RUNNER_MANUALLY_TRAP_SIG=
 
 # disable the log by default, because it is too large
 ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=
 
-ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/docker-init", "--", "/entrypoint.sh"]
 CMD ["/home/runner/run.sh"]

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -24,7 +24,6 @@ RUN apt-get update -y \
         # https://github.com/ruby/setup-ruby#using-self-hosted-runners
         libyaml-dev \
         # dockerd dependencies
-        tini \
         iptables
 
 # KEEP LESS PACKAGES:
@@ -78,5 +77,5 @@ VOLUME /var/lib/docker
 ENV ImageOS=ubuntu20
 
 USER runner
-ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/docker-init", "--", "/entrypoint.sh"]
 CMD ["/home/runner/run.sh"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We extend the official image to solve the following issues:
   This repository provides a multi-architectures image.
   ([community#56720](https://github.com/orgs/community/discussions/56720))~ (resolved by [actions/runner#2601](https://github.com/actions/runner/pull/2601))
 - We would like to run both runner and Dockerd in same container for the resource efficiency of Kubernetes nodes.
-  This image starts Dockerd under [tini](https://github.com/krallin/tini).
+  This image starts Dockerd under docker-init.
 - ~We need to use [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby#using-self-hosted-runners) but it does not support Debian.
   This image is based on Ubuntu. ([actions-runner-controller#2610](https://github.com/actions/actions-runner-controller/issues/2610))~ (resolved by [actions/runner#2651](https://github.com/actions/runner/pull/2651))
 - We need some essential packages such as `git`


### PR DESCRIPTION
This will replace `tini` with `docker-init`.

> NOTE: If you are using Docker 1.13 or greater, Tini is included in Docker itself.
> https://github.com/krallin/tini?tab=readme-ov-file#using-tini