### PR TITLE
Remove /var/lib/apt/lists from images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,14 @@ RUN sudo apt-get update -y \
         # https://github.com/ruby/setup-ruby#using-self-hosted-runners
         libyaml-dev \
         # dockerd dependencies
-        iptables
+        iptables \
+    && sudo rm -rf /var/lib/apt/lists/*
 
 # KEEP LESS PACKAGES:
 # We'd like to keep this image small for maintanability and security.
 # See also,
 # https://github.com/actions/actions-runner-controller/pull/2050
 # https://github.com/actions/actions-runner-controller/blob/master/runner/actions-runner.ubuntu-22.04.dockerfile
-
-# keep /var/lib/apt/lists to reduce time of apt-get update in a job
 
 # some setup actions store cache into /opt/hostedtoolcache
 ENV RUNNER_TOOL_CACHE /opt/hostedtoolcache

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -24,15 +24,14 @@ RUN apt-get update -y \
         # https://github.com/ruby/setup-ruby#using-self-hosted-runners
         libyaml-dev \
         # dockerd dependencies
-        iptables
+        iptables \
+    && rm -rf /var/lib/apt/lists/*
 
 # KEEP LESS PACKAGES:
 # We'd like to keep this image small for maintanability and security.
 # See also,
 # https://github.com/actions/actions-runner-controller/pull/2050
 # https://github.com/actions/actions-runner-controller/blob/master/runner/actions-runner.ubuntu-22.04.dockerfile
-
-# keep /var/lib/apt/lists to reduce time of apt-get update in a job
 
 # set up the runner environment,
 # based on https://github.com/actions/runner/blob/v2.309.0/images/Dockerfile


### PR DESCRIPTION
I think `/var/lib/apt/lists` does not reduce time of apt-get update, because it will be outdated after release.
