### PR TITLE
Remove extra repository to reduce time of apt-get update

### DIFF
--- a/.github/workflows/reusable--e2e-test-jobs.yaml
+++ b/.github/workflows/reusable--e2e-test-jobs.yaml
@@ -60,3 +60,7 @@ jobs:
 
       # Test service container
       - run: curl -sf http://localhost:8080
+
+      # Test apt
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y --no-install-recommends fonts-noto

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN sudo apt-get update -y \
         libyaml-dev \
         # dockerd dependencies
         iptables \
+    # Remove the extra repository to reduce time of apt-get update
+    && sudo add-apt-repository -r ppa:git-core/ppa \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # KEEP LESS PACKAGES:


### PR DESCRIPTION
It sometimes takes a long time to fetch `ppa:git-core/ppa`.

## Related change
- https://github.com/actions/runner/pull/3273