### PR TITLE
add gh-cli to actions-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,14 @@ RUN sudo apt-get update -y \
         libyaml-dev \
         # dockerd dependencies
         iptables \
+    # install gh cli
+    && (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+    && sudo mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt update \
+    && sudo apt install gh -y \
     # Remove the extra repository to reduce time of apt-get update
     && sudo add-apt-repository -r ppa:git-core/ppa \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -25,6 +25,14 @@ RUN apt-get update -y \
         libyaml-dev \
         # dockerd dependencies
         iptables \
+    # install gh cli
+    && (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+    && sudo mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt update \
+    && sudo apt install gh -y \
     && rm -rf /var/lib/apt/lists/*
 
 # KEEP LESS PACKAGES:


### PR DESCRIPTION
I would like to install gh cli because I want to use it in some situations and I think it would be more convenient to use it, but if it is difficult due to other reasons, please reject it.