### PR TITLE
Remove dummy runner from e2e-test

### DIFF
--- a/.github/workflows/reusable--e2e-test.yaml
+++ b/.github/workflows/reusable--e2e-test.yaml
@@ -43,13 +43,6 @@ jobs:
           ARC_RUNNER_NAME: ${{ inputs.runner-base-name }}
           ARC_RUNNER_IMAGE_URI: ${{ inputs.runner-image-uri }}
 
-      # Register a dummy runner scale set to ensure GitHub picks the jobs.
-      - run: sleep 60
-      - run: make runner-scale-set
-        env:
-          ARC_RUNNER_NAME: ${{ inputs.runner-base-name }}-dummy
-          ARC_RUNNER_IMAGE_URI: ${{ inputs.runner-image-uri }}
-
       - run: make wait-for-runner
         env:
           ARC_RUNNER_NAME: ${{ inputs.runner-base-name }}


### PR DESCRIPTION
## Issue
- Related to https://github.com/quipper/sre-issues/issues/844
## Change
As of February 2025, we added a dummy runner step to ensure that the GitHub Actions control-plane notifies the jobs to ARC. I'm not sure why but now it seems no longer needed.
